### PR TITLE
103 is not a standard, this was only a draft.

### DIFF
--- a/codes/1.json
+++ b/codes/1.json
@@ -63,17 +63,6 @@
                 }
             }
         },
-        "103":{
-            "code":"103",
-            "title":"Checkpoint",
-            "summary":"resume aborted PUT or POST requests",
-            "descriptions":{
-                "wikipedia":{
-                    "body":"This code is used in the Resumable HTTP Requests Proposal to resume aborted PUT or POST requests.",
-                    "link":"http:\/\/en.wikipedia.org\/wiki\/List_of_HTTP_status_codes#103"
-                }
-            }
-        },
         "122":{
             "code":"122",
             "title":"Request-URI too long",


### PR DESCRIPTION
The 103 status comes from here: https://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal. It has never been in HTTP1.1, it was a draft.

Moreover, the Wikipedia link is not up-to-date.