### PR TITLE
Added non-standard 444 code for nginx

### DIFF
--- a/contents/codes/444.md
+++ b/contents/codes/444.md
@@ -1,0 +1,16 @@
+---
+# This is not a status code available in the standard, but it exists
+# with significant prominence in the wild
+set: 4
+code: 444
+title: Nginx closed connection without sending a response.
+---
+
+A non-standard status code introduced by [nginx][2] for the case when you need to close the connection without sending anything to client. Useful as counteraction for DDOS attacks. Client never sees this code, but it appears in log files.
+
+---
+
+* Source: [nginx documentation][1]
+
+[1]: <http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return>
+[2]: <http://nginx.org>

--- a/contents/codes/444.md
+++ b/contents/codes/444.md
@@ -6,7 +6,9 @@ code: 444
 title: Nginx closed connection without sending a response.
 ---
 
-A non-standard status code introduced by [nginx][2] for the case when you need to close the connection without sending anything to client. Useful as counteraction for DDOS attacks. Client never sees this code, but it appears in log files.
+A non-standard status code used to instruct nginx[2] to close the connection without sending a response to the client, most commonly used to deny malicious or malformed requests.
+
+This status code is not seen by the client, it only appears in nginx log files.
 
 ---
 

--- a/contents/codes/444.md
+++ b/contents/codes/444.md
@@ -6,7 +6,7 @@ code: 444
 title: Nginx closed connection without sending a response.
 ---
 
-A non-standard status code used to instruct nginx[2] to close the connection without sending a response to the client, most commonly used to deny malicious or malformed requests.
+A non-standard status code used to instruct [nginx][2] to close the connection without sending a response to the client, most commonly used to deny malicious or malformed requests.
 
 This status code is not seen by the client, it only appears in nginx log files.
 


### PR DESCRIPTION
444 code special code for nginx. It makes it close the connection without sending any response to client. Useful as counteraction for DDOS attacks. Cleint never sees this code, but it appears in logs. Reference: http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return