### PR TITLE
Add properties to status codes

### DIFF
--- a/contents/codes/100.md
+++ b/contents/codes/100.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":continue"
     "Go HTTP Status Constant": "http.StatusContinue"
     "Symfony HTTP Status Constant": "Response::HTTP_CONTINUE"
+standard: true
 ---
 
 The initial part of a request has been received and has not yet been rejected by the server. The server intends to send a final response after the request has been fully received and acted upon.

--- a/contents/codes/101.md
+++ b/contents/codes/101.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":switching_protocols"
     "Go HTTP Status Constant": "http.StatusSwitchingProtocols"
     "Symfony HTTP Status Constant": "Response::HTTP_SWITCHING_PROTOCOLS"
+standard: true
 ---
 
 The server understands and is willing to comply with the client's request, via the Upgrade header field<sup>[1](#ref-1)</sup>, for a change in the application protocol being used on this connection.

--- a/contents/codes/102.md
+++ b/contents/codes/102.md
@@ -5,6 +5,7 @@ title: Processing
 references:
     "Rails HTTP Status Symbol": ":processing"
     "Symfony HTTP Status Constant": "Response::HTTP_PROCESSING"
+standard: true
 ---
 
 An interim response used to inform the client that the server has accepted the complete request, but has not yet completed it.

--- a/contents/codes/200.md
+++ b/contents/codes/200.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":ok"
     "Go HTTP Status Constant": "http.StatusOK"
     "Symfony HTTP Status Constant": "Response::HTTP_OK"
+standard: true
 ---
 
 The request has succeeded.

--- a/contents/codes/201.md
+++ b/contents/codes/201.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":created"
     "Go HTTP Status Constant": "http.StatusCreated"
     "Symfony HTTP Status Constant": "Response::HTTP_CREATED"
+standard: true
 ---
 
 The request has been fulfilled and has resulted in one or more new resources being created.

--- a/contents/codes/202.md
+++ b/contents/codes/202.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":accepted"
     "Go HTTP Status Constant": "http.StatusAccepted"
     "Symfony HTTP Status Constant": "Response::HTTP_ACCEPTED"
+standard: true
 ---
 
 The request has been accepted for processing, but the processing has not been

--- a/contents/codes/203.md
+++ b/contents/codes/203.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":non_authoritative_information"
     "Go HTTP Status Constant": "http.StatusNonAuthoritativeInfo"
     "Symfony HTTP Status Constant": "Response::HTTP_NON_AUTHORITATIVE_INFORMATION"
+standard: true
 ---
 
 The request was successful but the enclosed payload has been modified from that of the origin server's [200 OK](/200) response by a transforming proxy<sup>[1](#ref-1)</sup>.

--- a/contents/codes/204.md
+++ b/contents/codes/204.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":no_content"
     "Go HTTP Status Constant": "http.StatusNoContent"
     "Symfony HTTP Status Constant": "Response::HTTP_NO_CONTENT"
+standard: true
 ---
 
 The server has successfully fulfilled the request and that there is no additional content to send in the response payload body.

--- a/contents/codes/205.md
+++ b/contents/codes/205.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":reset_content"
     "Go HTTP Status Constant": "http.StatusResetContent"
     "Symfony HTTP Status Constant": "Response::HTTP_RESET_CONTENT"
+standard: true
 ---
 
 The server has fulfilled the request and desires that the user agent reset the "document view", which caused the request to be sent, to its original state as received from the origin server.

--- a/contents/codes/206.md
+++ b/contents/codes/206.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":partial_content"
     "Go HTTP Status Constant": "http.StatusPartialContent"
     "Symfony HTTP Status Constant": "Response::HTTP_PARTIAL_CONTENT"
+standard: true
 ---
 
 The server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation that correspond to the satisfiable ranges found in the request's Range header field<sup>[1](#ref-1)</sup>.

--- a/contents/codes/207.md
+++ b/contents/codes/207.md
@@ -5,6 +5,7 @@ title: Multi-Status
 references:
     "Rails HTTP Status Symbol": ":multi_status"
     "Symfony HTTP Status Constant": "Response::HTTP_MULTI_STATUS"
+standard: true
 ---
 
 A Multi-Status response conveys information about multiple resources in situations where multiple status codes might be appropriate.

--- a/contents/codes/208.md
+++ b/contents/codes/208.md
@@ -4,6 +4,7 @@ code: 208
 title: Already Reported
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_ALREADY_REPORTED"
+standard: true
 ---
 
 Used inside a DAV: propstat response element to avoid enumerating the internal members of multiple bindings to the same collection repeatedly.

--- a/contents/codes/226.md
+++ b/contents/codes/226.md
@@ -5,6 +5,7 @@ title: IM Used
 references:
     "Rails HTTP Status Symbol": ":im_used"
     "Symfony HTTP Status Constant": "Response::HTTP_IM_USED"
+standard: true
 ---
 
 The server has fulfilled a GET request for the resource, and the response is a representation of the result of one or more instance-manipulations applied to the current instance.

--- a/contents/codes/300.md
+++ b/contents/codes/300.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":multiple_choices"
     "Go HTTP Status Constant": "http.StatusMultipleChoices"
     "Symfony HTTP Status Constant": "Response::HTTP_MULTIPLE_CHOICES"
+standard: true
 ---
 
 The target resource has more than one representation, each with its own more specific identifier, and information about the alternatives is being provided so that the user (or user agent) can select a preferred representation by redirecting its request to one or more of those identifiers.

--- a/contents/codes/301.md
+++ b/contents/codes/301.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":moved_permanently"
     "Go HTTP Status Constant": "http.StatusMovedPermanently"
     "Symfony HTTP Status Constant": "Response::HTTP_MOVED_PERMANENTLY"
+standard: true
 ---
 
 The target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.

--- a/contents/codes/302.md
+++ b/contents/codes/302.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":found"
     "Go HTTP Status Constant": "http.StatusFound"
     "Symfony HTTP Status Constant": "Response::HTTP_FOUND"
+standard: true
 ---
 
 The target resource resides temporarily under a different URI. Since the redirection might be altered on occasion, the client ought to continue to use the effective request URI for future requests.

--- a/contents/codes/303.md
+++ b/contents/codes/303.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":see_other"
     "Go HTTP Status Constant": "http.StatusSeeOther"
     "Symfony HTTP Status Constant": "Response::HTTP_SEE_OTHER"
+standard: true
 ---
 
 The server is redirecting the user agent to a different resource, as indicated by a URI in the Location header field, which is intended to provide an indirect response to the original request.

--- a/contents/codes/304.md
+++ b/contents/codes/304.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":not_modified"
     "Go HTTP Status Constant": "http.StatusNotModified"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_MODIFIED"
+standard: true
 ---
 
 A conditional GET or HEAD request has been received and would have resulted in a [200 OK](/200) response if it were not for the fact that the condition evaluated to false.

--- a/contents/codes/305.md
+++ b/contents/codes/305.md
@@ -2,11 +2,12 @@
 set: 3
 code: 305
 title: Use Proxy
-#references:
-#   "Rails HTTP Status Symbol": "use_proxy"
-#   "Go HTTP Status Constant": "http.StatusUseProxy"
-#   "Symfony HTTP Status Constant": "Response::HTTP_USE_PROXY"
-#   - Due to deprecation we won't show this... but should we?
+references:
+   "Rails HTTP Status Symbol": "use_proxy"
+   "Go HTTP Status Constant": "http.StatusUseProxy"
+   "Symfony HTTP Status Constant": "Response::HTTP_USE_PROXY"
+standard: true
+deprecated: true
 ---
 
 Defined in a previous version of this specification and is now deprecated, due to security concerns regarding in-band configuration of a proxy.

--- a/contents/codes/307.md
+++ b/contents/codes/307.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":temporary_redirect"
     "Go HTTP Status Constant": "http.StatusTemporaryRedirect"
     "Symfony HTTP Status Constant": "Response::HTTP_TEMPORARY_REDIRECT"
+standard: true
 ---
 
 The target resource resides temporarily under a different URI and the user agent MUST NOT change the request method if it performs an automatic redirection to that URI.

--- a/contents/codes/308.md
+++ b/contents/codes/308.md
@@ -4,6 +4,7 @@ code: 308
 title: Permanent Redirect
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_PERMANENTLY_REDIRECT"
+standard: true
 ---
 
 The target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.

--- a/contents/codes/400.md
+++ b/contents/codes/400.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": "bad_request"
     "Go HTTP Status Constant": "http.StatusBadRequest"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_REQUEST"
+standard: true
 ---
 
 The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).

--- a/contents/codes/401.md
+++ b/contents/codes/401.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":unauthorized"
     "Go HTTP Status Constant": "http.StatusUnauthorized"
     "Symfony HTTP Status Constant": "Response::HTTP_UNAUTHORIZED"
+standard: true
 ---
 
 The request has not been applied because it lacks valid authentication credentials for the target resource.

--- a/contents/codes/402.md
+++ b/contents/codes/402.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":payment_required"
     "Go HTTP Status Constant": "http.StatusPaymentRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_PAYMENT_REQUIRED"
+standard: true
 ---
 
 Reserved for future use.

--- a/contents/codes/403.md
+++ b/contents/codes/403.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":forbidden"
     "Go HTTP Status Constant": "http.StatusForbidden"
     "Symfony HTTP Status Constant": "Response::HTTP_FORBIDDEN"
+standard: true
 ---
 
 The server understood the request but refuses to authorize it.

--- a/contents/codes/404.md
+++ b/contents/codes/404.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":not_found"
     "Go HTTP Status Constant": "http.StatusNotFound"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_FOUND"
+standard: true
 ---
 
 The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.

--- a/contents/codes/405.md
+++ b/contents/codes/405.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":method_not_allowed"
     "Go HTTP Status Constant": "http.StatusMethodNotAllowed"
     "Symfony HTTP Status Constant": "Response::HTTP_METHOD_NOT_ALLOWED"
+standard: true
 ---
 
 The method received in the request-line is known by the origin server but not supported by the target resource.

--- a/contents/codes/406.md
+++ b/contents/codes/406.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":not_acceptable"
     "Go HTTP Status Constant": "http.StatusNotAcceptable"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_ACCEPTABLE"
+standard: true
 ---
 
 The target resource does not have a current representation that would be acceptable to the user agent, according to the proactive negotiation header fields received in the request<sup>[1](#ref-1)</sup>, and the server is unwilling to supply a default representation.

--- a/contents/codes/407.md
+++ b/contents/codes/407.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":proxy_authentication_required"
     "Go HTTP Status Constant": "http.StatusProxyAuthRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_PROXY_AUTHENTICATION_REQUIRED"
+standard: true
 ---
 
 Similar to [401 Unauthorized](/401), but it indicates that the client needs to authenticate itself in order to use a proxy.

--- a/contents/codes/408.md
+++ b/contents/codes/408.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":request_timeout"
     "Go HTTP Status Constant": "http.StatusRequestTimeout"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_TIMEOUT"
+standard: true
 ---
 
 The server did not receive a complete request message within the time that it was prepared to wait.

--- a/contents/codes/409.md
+++ b/contents/codes/409.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":conflict"
     "Go HTTP Status Constant": "http.StatusConflict"
     "Symfony HTTP Status Constant": "Response::HTTP_CONFLICT"
+standard: true
 ---
 
 The request could not be completed due to a conflict with the current state of the target resource. This code is used in situations where the user might be able to resolve the conflict and resubmit the request.

--- a/contents/codes/410.md
+++ b/contents/codes/410.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":gone"
     "Go HTTP Status Constant": "http.StatusGone"
     "Symfony HTTP Status Constant": "Response::HTTP_GONE"
+standard: true
 ---
 
 The target resource is no longer available at the origin server and that this condition is likely to be permanent.

--- a/contents/codes/411.md
+++ b/contents/codes/411.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":length_required"
     "Go HTTP Status Constant": "http.StatusLengthRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_LENGTH_REQUIRED"
+standard: true
 ---
 
 The server refuses to accept the request without a defined Content-Length<sup>[1](#ref-1)</sup>.

--- a/contents/codes/412.md
+++ b/contents/codes/412.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":precondition_failed"
     "Go HTTP Status Constant": "http.StatusPreconditionFailed"
     "Symfony HTTP Status Constant": "Response::HTTP_PRECONDITION_FAILED"
+standard: true
 ---
 
 One or more conditions given in the request header fields evaluated to false when tested on the server.

--- a/contents/codes/413.md
+++ b/contents/codes/413.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":request_entity_too_large"
     "Go HTTP Status Constant": "http.StatusRequestEntityTooLarge"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_ENTITY_TOO_LARGE"
+standard: true
 ---
 
 The server is refusing to process a request because the request payload is larger than the server is willing or able to process.

--- a/contents/codes/414.md
+++ b/contents/codes/414.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":request_uri_too_long"
     "Go HTTP Status Constant": "http.StatusRequestURITooLong"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_URI_TOO_LONG"
+standard: true
 ---
 
 The server is refusing to service the request because the request-target<sup>[1](#ref-1)</sup> is longer than the server is willing to interpret.

--- a/contents/codes/415.md
+++ b/contents/codes/415.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":unsupported_media_type"
     "Go HTTP Status Constant": "http.StatusUnsupportedMediaType"
     "Symfony HTTP Status Constant": "Response::HTTP_UNSUPPORTED_MEDIA_TYPE"
+standard: true
 ---
 
 The origin server is refusing to service the request because the payload is in a format not supported by this method on the target resource.

--- a/contents/codes/416.md
+++ b/contents/codes/416.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":requested_range_not_satisfiable"
     "Go HTTP Status Constant": "http.StatusRequestedRangeNotSatisfiable"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE"
+standard: true
 ---
 
 None of the ranges in the request's Range header field<sup>[1](#ref-1)</sup> overlap the current extent of the selected resource or that the set of ranges requested has been rejected due to invalid ranges or an excessive request of small or overlapping ranges.

--- a/contents/codes/417.md
+++ b/contents/codes/417.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":expectation_failed"
     "Go HTTP Status Constant": "http.StatusExpectationFailed"
     "Symfony HTTP Status Constant": "Response::HTTP_EXPECTATION_FAILED"
+standard: true
 ---
 
 The expectation given in the request's Expect header field<sup>[1](#ref-1)</sup> could not be met by at least one of the inbound servers.

--- a/contents/codes/418.md
+++ b/contents/codes/418.md
@@ -5,6 +5,7 @@ title: I'm a teapot
 references:
     "Go HTTP Status Constant": "http.StatusTeapot"
     "Symfony HTTP Status Constant": "Response::HTTP_I_AM_A_TEAPOT"
+standard: true
 ---
 
 Any attempt to brew coffee with a teapot should result in the error code "418 I'm a teapot". The resulting entity body MAY be short and stout.

--- a/contents/codes/421.md
+++ b/contents/codes/421.md
@@ -4,6 +4,7 @@ code: 421
 title: Misdirected Request
 references:
     "Rails HTTP Status Symbol": ":misdirected_request"
+standard: true
 ---
 
 The request was directed at a server that is not able to produce a response. This can be sent by a server that is not configured to produce responses for the combination of scheme and authority that are included in the request URI.

--- a/contents/codes/422.md
+++ b/contents/codes/422.md
@@ -5,6 +5,7 @@ title: Unprocessable Entity
 references:
     "Rails HTTP Status Symbol": ":unprocessable_entity"
     "Symfony HTTP Status Constant": "Response::HTTP_UNPROCESSABLE_ENTITY"
+standard: true
 ---
 
 The server understands the content type of the request entity (hence a [415 Unsupported Media Type](/415) status code is inappropriate), and the syntax of the request entity is correct (thus a [400 Bad Request](/400) status code is inappropriate) but was unable to process the contained instructions.

--- a/contents/codes/423.md
+++ b/contents/codes/423.md
@@ -5,6 +5,7 @@ title: Locked
 references:
     "Rails HTTP Status Symbol": ":locked"
     "Symfony HTTP Status Constant": "Response::HTTP_LOCKED"
+standard: true
 ---
 
 The source or destination resource of a method is locked.

--- a/contents/codes/424.md
+++ b/contents/codes/424.md
@@ -5,6 +5,7 @@ title: Failed Dependency
 references:
     "Rails HTTP Status Symbol": "failed_dependency"
     "Symfony HTTP Status Constant": "Response::HTTP_FAILED_DEPENDENCY"
+standard: true
 ---
 
 The method could not be performed on the resource because the requested action depended on another action and that action failed.

--- a/contents/codes/426.md
+++ b/contents/codes/426.md
@@ -5,6 +5,7 @@ title: Upgrade Required
 references:
     "Rails HTTP Status Symbol": ":upgrade_required"
     "Symfony HTTP Status Constant": "Response::HTTP_UPGRADE_REQUIRED"
+standard: true
 ---
 
 The server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol.

--- a/contents/codes/428.md
+++ b/contents/codes/428.md
@@ -4,6 +4,7 @@ code: 428
 title: Precondition Required
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_PRECONDITION_REQUIRED"
+standard: true
 ---
 
 The origin server requires the request to be conditional.

--- a/contents/codes/429.md
+++ b/contents/codes/429.md
@@ -4,6 +4,7 @@ code: 429
 title: Too Many Requests
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_TOO_MANY_REQUESTS"
+standard: true
 ---
 
 The user has sent too many requests in a given amount of time ("rate limiting").

--- a/contents/codes/431.md
+++ b/contents/codes/431.md
@@ -4,6 +4,7 @@ code: 431
 title: Request Header Fields Too Large
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE"
+standard: true
 ---
 
 The server is unwilling to process the request because its header fields are too large. The request MAY be resubmitted after reducing the size of the request header fields.

--- a/contents/codes/444.md
+++ b/contents/codes/444.md
@@ -2,6 +2,7 @@
 set: 4
 code: 444
 title: Connection Closed Without Response
+standard: false
 ---
 
 A non-standard status code used to instruct [nginx][2] to close the connection without sending a response to the client, most commonly used to deny malicious or malformed requests.

--- a/contents/codes/451.md
+++ b/contents/codes/451.md
@@ -5,6 +5,7 @@ title: Unavailable For Legal Reasons
 proposal: true
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_UNAVAILABLE_FOR_LEGAL_REASONS"
+standard: true
 ---
 
 The server is denying access to the resource as a consequence of a legal demand.

--- a/contents/codes/499.md
+++ b/contents/codes/499.md
@@ -1,9 +1,8 @@
 ---
-# This is not a status code available in the standard, but it exists
-# with significant prominence in the wild
 set: 4
 code: 499
 title: Client Closed Request
+standard: false
 ---
 
 A non-standard status code introduced by [nginx][2] for the case when a client closes the connection while nginx is processing the request.

--- a/contents/codes/500.md
+++ b/contents/codes/500.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":internal_server_error"
     "Go HTTP Status Constant": "http.StatusInternalServerError"
     "Symfony HTTP Status Constant": "Response::HTTP_INTERNAL_SERVER_ERROR"
+standard: true
 ---
 
 The server encountered an unexpected condition that prevented it from fulfilling the request.

--- a/contents/codes/501.md
+++ b/contents/codes/501.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":not_implemented"
     "Go HTTP Status Constant": "http.StatusNotImplemented"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_IMPLEMENTED"
+standard: true
 ---
 
 The server does not support the functionality required to fulfill the request.

--- a/contents/codes/502.md
+++ b/contents/codes/502.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":bad_gateway"
     "Go HTTP Status Constant": "http.StatusBadGateway"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_GATEWAY"
+standard: true
 ---
 
 The server, while acting as a gateway or proxy, received an invalid response from an inbound server it accessed while attempting to fulfill the request.

--- a/contents/codes/503.md
+++ b/contents/codes/503.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":service_unavailable"
     "Go HTTP Status Constant": "http.StatusServiceUnavailable"
     "Symfony HTTP Status Constant": "Response::HTTP_SERVICE_UNAVAILABLE"
+standard: true
 ---
 
 The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.

--- a/contents/codes/504.md
+++ b/contents/codes/504.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":gateway_timeout"
     "Go HTTP Status Constant": "http.StatusGatewayTimeout"
     "Symfony HTTP Status Constant": "Response::HTTP_GATEWAY_TIMEOUT"
+standard: true
 ---
 
 The server, while acting as a gateway or proxy, did not receive a timely response from an upstream server it needed to access in order to complete the request.

--- a/contents/codes/505.md
+++ b/contents/codes/505.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":http_version_not_supported"
     "Go HTTP Status Constant": "http.StatusHTTPVersionNotSupported"
     "Symfony HTTP Status Constant": "Response::HTTP_VERSION_NOT_SUPPORTED"
+standard: true
 ---
 
 The server does not support, or refuses to support, the major version of HTTP that was used in the request message.

--- a/contents/codes/506.md
+++ b/contents/codes/506.md
@@ -4,6 +4,7 @@ code: 506
 title: Variant Also Negotiates
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL"
+standard: true
 ---
 
 The server has an internal configuration error: the chosen variant resource is configured to engage in transparent content negotiation itself, and is therefore not a proper end point in the negotiation process.

--- a/contents/codes/507.md
+++ b/contents/codes/507.md
@@ -5,6 +5,7 @@ title: Insufficient Storage
 references:
     "Rails HTTP Status Symbol": ":insufficient_storage"
     "Symfony HTTP Status Constant": "Response::HTTP_INSUFFICIENT_STORAGE"
+standard: true
 ---
 
 The method could not be performed on the resource because the server is unable to store the representation needed to successfully complete the request.

--- a/contents/codes/508.md
+++ b/contents/codes/508.md
@@ -4,6 +4,7 @@ code: 508
 title: Loop Detected
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_LOOP_DETECTED"
+standard: true
 ---
 
 The server terminated an operation because it encountered an infinite loop while processing a request with "Depth: infinity". This status indicates that the entire operation failed.

--- a/contents/codes/510.md
+++ b/contents/codes/510.md
@@ -5,6 +5,7 @@ title: Not Extended
 references:
     "Rails HTTP Status Symbol": ":not_extended"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_EXTENDED"
+standard: true
 ---
 
 The policy for accessing the resource has not been met in the request. The server should send back all the information necessary for the client to issue an extended request.

--- a/contents/codes/511.md
+++ b/contents/codes/511.md
@@ -4,6 +4,7 @@ code: 511
 title: Network Authentication Required
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_NETWORK_AUTHENTICATION_REQUIRED"
+standard: true
 ---
 
 The client needs to authenticate to gain network access.

--- a/contents/codes/599.md
+++ b/contents/codes/599.md
@@ -1,9 +1,8 @@
 ---
-# This is not a status code available in the standard, but it exists
-# with significant prominence in the wild
 set: 5
 code: 599
 title: Network Connect Timeout Error
+standard: false
 ---
 
 This status code is not specified in any RFCs, but is used by some HTTP proxies to signal a network connect timeout behind the proxy to a client in front of the proxy.

--- a/contents/style.scss
+++ b/contents/style.scss
@@ -106,6 +106,10 @@ code {
           font-weight: bold;
           width: 34px;
         }
+
+        span.non-standard {
+          color: #556270;
+        }
       }
     }
   }

--- a/templates/index.jade
+++ b/templates/index.jade
@@ -1,5 +1,11 @@
 extends layout.jade
 
+mixin statuscode(code)
+  if !code.standard
+    li #[a(href='/#{code.code}', title='Non-standard') #[span(class='non-standard') !{code.code}] #{code.title}]
+  else
+    li #[a(href='/#{code.code}') #[span !{code.code}] #{code.title}]
+
 block contents
   .hero.introduction: .container: .row: .twelve.columns !{contents}
 
@@ -8,4 +14,4 @@ block contents
       ul
         li #[h2 !{group.title}]
         each code in group.items
-          li #[a(href='/#{code.code}') #[span !{code.code}] #{code.title}]
+          +statuscode(code)


### PR DESCRIPTION
This pull request has 2 components: adding a standard true/false to each status code (and deprecated on one), which will be important for the api, and adding a different display for non-standard codes on the homepage.

I'm not sure if I like the different display, while it's good to differentiate between standard and non-standard, having a separate link colour for non-standard isn't self explanatory and may lead to confusion ("Why are these different...").

Here's how it would look:

<img width="317" alt="screen shot 2016-04-23 at 03 07 38" src="https://cloud.githubusercontent.com/assets/349689/14758688/92861b44-0900-11e6-8103-b6d668b21add.png">

Please share any thoughts on the display, thank you.