### PR TITLE
Adds Share buttons for Twitter, GitHub and Pinboard

### DIFF
--- a/contents/style.scss
+++ b/contents/style.scss
@@ -87,6 +87,24 @@ code {
   }
 }
 
+.share {
+  @extend .u-full-width;
+  padding: 14px 0px;
+  background-color: #f9f9f9;
+  margin-bottom: 20px;
+
+  a {
+    color: #556270;
+    margin-right: 10px;
+    font-size: 12px;
+    font-weight: normal;
+
+    &:hover {
+      color: #fd55a2;
+    }
+  }
+}
+
 .codes {
   margin-bottom: 40px;
 

--- a/templates/index.jade
+++ b/templates/index.jade
@@ -4,10 +4,17 @@ block banner
   .banner: .container: .row: .twelve.columns
     p Sponsored by #[a(href='https://www.runscope.com/t/httpstatuses') Runscope &mdash; API Monitoring & Testing]
 
+block share
+    a.twitter(href='https://twitter.com/intent/tweet?hashtags=httpstatuses&text=Helpful%20HTTP%20Status%20Code%20reference%20site&url=https%3A%2F%2Fhttpstatuses.com&via=citricsquid') &commat; Share on Twitter
+    a.github(href='https://github.com/citricsquid/httpstatuses') &bigstar; Star on GitHub
+    a.pinboard(target='_blank', href='https://pinboard.in/add?showtags=yes&url=https%3A%2F%2Fhttpstatuses.com&description=HTTP%20Status%20Code%20Reference%20Site&title=httpstatuses.com&tags=reference,development') &oplus; Add to Pinboard
+
 block contents
   block banner
   .hero.introduction: .container: .row: .twelve.columns
     != contents
+  .share: .container: .row: .twelve.columns
+    block share
 
   .container.codes: .row: .twelve.columns
     each group in groups.codes


### PR DESCRIPTION
I played around with a number of different styles and this is the one that I'm most happy with, everything is aligned and there's a separation between the introduction, share links and then the content. I'm not super in love with it, but it works.

![screen shot 2016-04-27 at 23 22 53](https://cloud.githubusercontent.com/assets/349689/14870686/d51cf096-0cd3-11e6-802b-7242b2bb18a9.png)
