### PR TITLE
Add Python status constants

### DIFF
--- a/contents/codes/100.md
+++ b/contents/codes/100.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":continue"
     "Go HTTP Status Constant": "http.StatusContinue"
     "Symfony HTTP Status Constant": "Response::HTTP_CONTINUE"
+    "Python HTTP Status Constant": "httplib.CONTINUE"
 ---
 
 The initial part of a request has been received and has not yet been rejected by the server. The server intends to send a final response after the request has been fully received and acted upon.

--- a/contents/codes/100.md
+++ b/contents/codes/100.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":continue"
     "Go HTTP Status Constant": "http.StatusContinue"
     "Symfony HTTP Status Constant": "Response::HTTP_CONTINUE"
-    "Python HTTP Status Constant": "httplib.CONTINUE"
+    "Python2 HTTP Status Constant": "httplib.CONTINUE"
+    "Python3+ HTTP Status Constant": "http.client.CONTINUE"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.CONTINUE"
 ---
 
 The initial part of a request has been received and has not yet been rejected by the server. The server intends to send a final response after the request has been fully received and acted upon.

--- a/contents/codes/101.md
+++ b/contents/codes/101.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":switching_protocols"
     "Go HTTP Status Constant": "http.StatusSwitchingProtocols"
     "Symfony HTTP Status Constant": "Response::HTTP_SWITCHING_PROTOCOLS"
+    "Python HTTP Status Constant": "httplib.SWITCHING_PROTOCOLS"
 ---
 
 The server understands and is willing to comply with the client's request, via the Upgrade header field<sup>[1](#ref-1)</sup>, for a change in the application protocol being used on this connection.

--- a/contents/codes/101.md
+++ b/contents/codes/101.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":switching_protocols"
     "Go HTTP Status Constant": "http.StatusSwitchingProtocols"
     "Symfony HTTP Status Constant": "Response::HTTP_SWITCHING_PROTOCOLS"
-    "Python HTTP Status Constant": "httplib.SWITCHING_PROTOCOLS"
+    "Python2 HTTP Status Constant": "httplib.SWITCHING_PROTOCOLS"
+    "Python3+ HTTP Status Constant": "http.client.SWITCHING_PROTOCOLS"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.SWITCHING_PROTOCOLS"
 ---
 
 The server understands and is willing to comply with the client's request, via the Upgrade header field<sup>[1](#ref-1)</sup>, for a change in the application protocol being used on this connection.

--- a/contents/codes/200.md
+++ b/contents/codes/200.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":ok"
     "Go HTTP Status Constant": "http.StatusOK"
     "Symfony HTTP Status Constant": "Response::HTTP_OK"
+    "Python HTTP Status Constant": "httplib.OK"
 ---
 
 The request has succeeded.

--- a/contents/codes/200.md
+++ b/contents/codes/200.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":ok"
     "Go HTTP Status Constant": "http.StatusOK"
     "Symfony HTTP Status Constant": "Response::HTTP_OK"
-    "Python HTTP Status Constant": "httplib.OK"
+    "Python2 HTTP Status Constant": "httplib.OK"
+    "Python3+ HTTP Status Constant": "http.client.OK"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.OK"
 ---
 
 The request has succeeded.

--- a/contents/codes/201.md
+++ b/contents/codes/201.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":created"
     "Go HTTP Status Constant": "http.StatusCreated"
     "Symfony HTTP Status Constant": "Response::HTTP_CREATED"
+    "Python HTTP Status Constant": "httplib.CREATED"
 ---
 
 The request has been fulfilled and has resulted in one or more new resources being created.

--- a/contents/codes/201.md
+++ b/contents/codes/201.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":created"
     "Go HTTP Status Constant": "http.StatusCreated"
     "Symfony HTTP Status Constant": "Response::HTTP_CREATED"
-    "Python HTTP Status Constant": "httplib.CREATED"
+    "Python2 HTTP Status Constant": "httplib.CREATED"
+    "Python3+ HTTP Status Constant": "http.client.CREATED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.CREATED"
 ---
 
 The request has been fulfilled and has resulted in one or more new resources being created.

--- a/contents/codes/202.md
+++ b/contents/codes/202.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":accepted"
     "Go HTTP Status Constant": "http.StatusAccepted"
     "Symfony HTTP Status Constant": "Response::HTTP_ACCEPTED"
+    "Python HTTP Status Constant": "httplib.ACCEPTED"
 ---
 
 The request has been accepted for processing, but the processing has not been

--- a/contents/codes/202.md
+++ b/contents/codes/202.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":accepted"
     "Go HTTP Status Constant": "http.StatusAccepted"
     "Symfony HTTP Status Constant": "Response::HTTP_ACCEPTED"
-    "Python HTTP Status Constant": "httplib.ACCEPTED"
+    "Python2 HTTP Status Constant": "httplib.ACCEPTED"
+    "Python3+ HTTP Status Constant": "http.client.ACCEPTED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.ACCEPTED"
 ---
 
 The request has been accepted for processing, but the processing has not been

--- a/contents/codes/203.md
+++ b/contents/codes/203.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":non_authoritative_information"
     "Go HTTP Status Constant": "http.StatusNonAuthoritativeInfo"
     "Symfony HTTP Status Constant": "Response::HTTP_NON_AUTHORITATIVE_INFORMATION"
+    "Python HTTP Status Constant": "httplib.NON_AUTHORITATIVE_INFORMATION"
 ---
 
 The request was successful but the enclosed payload has been modified from that of the origin server's [200 OK](/200) response by a transforming proxy<sup>[1](#ref-1)</sup>.

--- a/contents/codes/203.md
+++ b/contents/codes/203.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":non_authoritative_information"
     "Go HTTP Status Constant": "http.StatusNonAuthoritativeInfo"
     "Symfony HTTP Status Constant": "Response::HTTP_NON_AUTHORITATIVE_INFORMATION"
-    "Python HTTP Status Constant": "httplib.NON_AUTHORITATIVE_INFORMATION"
+    "Python2 HTTP Status Constant": "httplib.NON_AUTHORITATIVE_INFORMATION"
+    "Python3+ HTTP Status Constant": "http.client.NON_AUTHORITATIVE_INFORMATION"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NON_AUTHORITATIVE_INFORMATION"
 ---
 
 The request was successful but the enclosed payload has been modified from that of the origin server's [200 OK](/200) response by a transforming proxy<sup>[1](#ref-1)</sup>.

--- a/contents/codes/204.md
+++ b/contents/codes/204.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":no_content"
     "Go HTTP Status Constant": "http.StatusNoContent"
     "Symfony HTTP Status Constant": "Response::HTTP_NO_CONTENT"
+    "Python HTTP Status Constant": "httplib.NO_CONTENT"
 ---
 
 The server has successfully fulfilled the request and that there is no additional content to send in the response payload body.

--- a/contents/codes/204.md
+++ b/contents/codes/204.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":no_content"
     "Go HTTP Status Constant": "http.StatusNoContent"
     "Symfony HTTP Status Constant": "Response::HTTP_NO_CONTENT"
-    "Python HTTP Status Constant": "httplib.NO_CONTENT"
+    "Python2 HTTP Status Constant": "httplib.NO_CONTENT"
+    "Python3+ HTTP Status Constant": "http.client.NO_CONTENT"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NO_CONTENT"
 ---
 
 The server has successfully fulfilled the request and that there is no additional content to send in the response payload body.

--- a/contents/codes/205.md
+++ b/contents/codes/205.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":reset_content"
     "Go HTTP Status Constant": "http.StatusResetContent"
     "Symfony HTTP Status Constant": "Response::HTTP_RESET_CONTENT"
+    "Python HTTP Status Constant": "httplib.RESET_CONTENT"
 ---
 
 The server has fulfilled the request and desires that the user agent reset the "document view", which caused the request to be sent, to its original state as received from the origin server.

--- a/contents/codes/205.md
+++ b/contents/codes/205.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":reset_content"
     "Go HTTP Status Constant": "http.StatusResetContent"
     "Symfony HTTP Status Constant": "Response::HTTP_RESET_CONTENT"
-    "Python HTTP Status Constant": "httplib.RESET_CONTENT"
+    "Python2 HTTP Status Constant": "httplib.RESET_CONTENT"
+    "Python3+ HTTP Status Constant": "http.client.RESET_CONTENT"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.RESET_CONTENT"
 ---
 
 The server has fulfilled the request and desires that the user agent reset the "document view", which caused the request to be sent, to its original state as received from the origin server.

--- a/contents/codes/206.md
+++ b/contents/codes/206.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":partial_content"
     "Go HTTP Status Constant": "http.StatusPartialContent"
     "Symfony HTTP Status Constant": "Response::HTTP_PARTIAL_CONTENT"
+    "Python HTTP Status Constant": "httplib.PARTIAL_CONTENT"
 ---
 
 The server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation that correspond to the satisfiable ranges found in the request's Range header field<sup>[1](#ref-1)</sup>.

--- a/contents/codes/206.md
+++ b/contents/codes/206.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":partial_content"
     "Go HTTP Status Constant": "http.StatusPartialContent"
     "Symfony HTTP Status Constant": "Response::HTTP_PARTIAL_CONTENT"
-    "Python HTTP Status Constant": "httplib.PARTIAL_CONTENT"
+    "Python2 HTTP Status Constant": "httplib.PARTIAL_CONTENT"
+    "Python3+ HTTP Status Constant": "http.client.PARTIAL_CONTENT"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.PARTIAL_CONTENT"
 ---
 
 The server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation that correspond to the satisfiable ranges found in the request's Range header field<sup>[1](#ref-1)</sup>.

--- a/contents/codes/300.md
+++ b/contents/codes/300.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":multiple_choices"
     "Go HTTP Status Constant": "http.StatusMultipleChoices"
     "Symfony HTTP Status Constant": "Response::HTTP_MULTIPLE_CHOICES"
+    "Python HTTP Status Constant": "httplib.MULTIPLE_CHOICES"
 ---
 
 The target resource has more than one representation, each with its own more specific identifier, and information about the alternatives is being provided so that the user (or user agent) can select a preferred representation by redirecting its request to one or more of those identifiers.

--- a/contents/codes/300.md
+++ b/contents/codes/300.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":multiple_choices"
     "Go HTTP Status Constant": "http.StatusMultipleChoices"
     "Symfony HTTP Status Constant": "Response::HTTP_MULTIPLE_CHOICES"
-    "Python HTTP Status Constant": "httplib.MULTIPLE_CHOICES"
+    "Python2 HTTP Status Constant": "httplib.MULTIPLE_CHOICES"
+    "Python3+ HTTP Status Constant": "http.client.MULTIPLE_CHOICES"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.MULTIPLE_CHOICES"
 ---
 
 The target resource has more than one representation, each with its own more specific identifier, and information about the alternatives is being provided so that the user (or user agent) can select a preferred representation by redirecting its request to one or more of those identifiers.

--- a/contents/codes/301.md
+++ b/contents/codes/301.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":moved_permanently"
     "Go HTTP Status Constant": "http.StatusMovedPermanently"
     "Symfony HTTP Status Constant": "Response::HTTP_MOVED_PERMANENTLY"
+    "Python HTTP Status Constant": "httplib.MOVED_PERMANENTLY"
 ---
 
 The target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.

--- a/contents/codes/301.md
+++ b/contents/codes/301.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":moved_permanently"
     "Go HTTP Status Constant": "http.StatusMovedPermanently"
     "Symfony HTTP Status Constant": "Response::HTTP_MOVED_PERMANENTLY"
-    "Python HTTP Status Constant": "httplib.MOVED_PERMANENTLY"
+    "Python2 HTTP Status Constant": "httplib.MOVED_PERMANENTLY"
+    "Python3+ HTTP Status Constant": "http.client.MOVED_PERMANENTLY"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.MOVED_PERMANENTLY"
 ---
 
 The target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.

--- a/contents/codes/302.md
+++ b/contents/codes/302.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":found"
     "Go HTTP Status Constant": "http.StatusFound"
     "Symfony HTTP Status Constant": "Response::HTTP_FOUND"
-    "Python HTTP Status Constant": "httplib.FOUND"
+    "Python2 HTTP Status Constant": "httplib.FOUND"
+    "Python3+ HTTP Status Constant": "http.client.FOUND"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.FOUND"
 ---
 
 The target resource resides temporarily under a different URI. Since the redirection might be altered on occasion, the client ought to continue to use the effective request URI for future requests.

--- a/contents/codes/302.md
+++ b/contents/codes/302.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":found"
     "Go HTTP Status Constant": "http.StatusFound"
     "Symfony HTTP Status Constant": "Response::HTTP_FOUND"
+    "Python HTTP Status Constant": "httplib.FOUND"
 ---
 
 The target resource resides temporarily under a different URI. Since the redirection might be altered on occasion, the client ought to continue to use the effective request URI for future requests.

--- a/contents/codes/303.md
+++ b/contents/codes/303.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":see_other"
     "Go HTTP Status Constant": "http.StatusSeeOther"
     "Symfony HTTP Status Constant": "Response::HTTP_SEE_OTHER"
+    "Python HTTP Status Constant": "httplib.SEE_OTHER"
 ---
 
 The server is redirecting the user agent to a different resource, as indicated by a URI in the Location header field, which is intended to provide an indirect response to the original request.

--- a/contents/codes/303.md
+++ b/contents/codes/303.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":see_other"
     "Go HTTP Status Constant": "http.StatusSeeOther"
     "Symfony HTTP Status Constant": "Response::HTTP_SEE_OTHER"
-    "Python HTTP Status Constant": "httplib.SEE_OTHER"
+    "Python2 HTTP Status Constant": "httplib.SEE_OTHER"
+    "Python3+ HTTP Status Constant": "http.client.SEE_OTHER"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.SEE_OTHER"
 ---
 
 The server is redirecting the user agent to a different resource, as indicated by a URI in the Location header field, which is intended to provide an indirect response to the original request.

--- a/contents/codes/304.md
+++ b/contents/codes/304.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":not_modified"
     "Go HTTP Status Constant": "http.StatusNotModified"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_MODIFIED"
+    "Python HTTP Status Constant": "httplib.NOT_MODIFIED"
 ---
 
 A conditional GET or HEAD request has been received and would have resulted in a [200 OK](/200) response if it were not for the fact that the condition evaluated to false.

--- a/contents/codes/304.md
+++ b/contents/codes/304.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":not_modified"
     "Go HTTP Status Constant": "http.StatusNotModified"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_MODIFIED"
-    "Python HTTP Status Constant": "httplib.NOT_MODIFIED"
+    "Python2 HTTP Status Constant": "httplib.NOT_MODIFIED"
+    "Python3+ HTTP Status Constant": "http.client.NOT_MODIFIED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NOT_MODIFIED"
 ---
 
 A conditional GET or HEAD request has been received and would have resulted in a [200 OK](/200) response if it were not for the fact that the condition evaluated to false.

--- a/contents/codes/305.md
+++ b/contents/codes/305.md
@@ -6,6 +6,7 @@ title: Use Proxy
 #   "Rails HTTP Status Symbol": "use_proxy"
 #   "Go HTTP Status Constant": "http.StatusUseProxy"
 #   "Symfony HTTP Status Constant": "Response::HTTP_USE_PROXY"
+#   "Python HTTP Status Constant": "httplib.USE_PROXY"
 #   - Due to deprecation we won't show this... but should we?
 ---
 

--- a/contents/codes/305.md
+++ b/contents/codes/305.md
@@ -6,7 +6,9 @@ title: Use Proxy
 #   "Rails HTTP Status Symbol": "use_proxy"
 #   "Go HTTP Status Constant": "http.StatusUseProxy"
 #   "Symfony HTTP Status Constant": "Response::HTTP_USE_PROXY"
-#   "Python HTTP Status Constant": "httplib.USE_PROXY"
+#   "Python2 HTTP Status Constant": "httplib.USE_PROXY"
+#   "Python3+ HTTP Status Constant": "http.client.USE_PROXY"
+#   "Python3.5+ HTTP Status Constant": "http.HTTPStatus.USE_PROXY"
 #   - Due to deprecation we won't show this... but should we?
 ---
 

--- a/contents/codes/307.md
+++ b/contents/codes/307.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":temporary_redirect"
     "Go HTTP Status Constant": "http.StatusTemporaryRedirect"
     "Symfony HTTP Status Constant": "Response::HTTP_TEMPORARY_REDIRECT"
+    "Python HTTP Status Constant": "httplib.TEMPORARY_REDIRECT"
 ---
 
 The target resource resides temporarily under a different URI and the user agent MUST NOT change the request method if it performs an automatic redirection to that URI.

--- a/contents/codes/307.md
+++ b/contents/codes/307.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":temporary_redirect"
     "Go HTTP Status Constant": "http.StatusTemporaryRedirect"
     "Symfony HTTP Status Constant": "Response::HTTP_TEMPORARY_REDIRECT"
-    "Python HTTP Status Constant": "httplib.TEMPORARY_REDIRECT"
+    "Python2 HTTP Status Constant": "httplib.TEMPORARY_REDIRECT"
+    "Python3+ HTTP Status Constant": "http.client.TEMPORARY_REDIRECT"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.TEMPORARY_REDIRECT"
 ---
 
 The target resource resides temporarily under a different URI and the user agent MUST NOT change the request method if it performs an automatic redirection to that URI.

--- a/contents/codes/400.md
+++ b/contents/codes/400.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": "bad_request"
     "Go HTTP Status Constant": "http.StatusBadRequest"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_REQUEST"
-    "Python HTTP Status Constant": "httplib.BAD_REQUEST"
+    "Python2 HTTP Status Constant": "httplib.BAD_REQUEST"
+    "Python3+ HTTP Status Constant": "http.client.BAD_REQUEST"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.BAD_REQUEST"
 ---
 
 The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).

--- a/contents/codes/400.md
+++ b/contents/codes/400.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": "bad_request"
     "Go HTTP Status Constant": "http.StatusBadRequest"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_REQUEST"
+    "Python HTTP Status Constant": "httplib.BAD_REQUEST"
 ---
 
 The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).

--- a/contents/codes/401.md
+++ b/contents/codes/401.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":unauthorized"
     "Go HTTP Status Constant": "http.StatusUnauthorized"
     "Symfony HTTP Status Constant": "Response::HTTP_UNAUTHORIZED"
-    "Python HTTP Status Constant": "httplib.UNAUTHORIZED"
+    "Python2 HTTP Status Constant": "httplib.UNAUTHORIZED"
+    "Python3+ HTTP Status Constant": "http.client.UNAUTHORIZED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.UNAUTHORIZED"
 ---
 
 The request has not been applied because it lacks valid authentication credentials for the target resource.

--- a/contents/codes/401.md
+++ b/contents/codes/401.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":unauthorized"
     "Go HTTP Status Constant": "http.StatusUnauthorized"
     "Symfony HTTP Status Constant": "Response::HTTP_UNAUTHORIZED"
+    "Python HTTP Status Constant": "httplib.UNAUTHORIZED"
 ---
 
 The request has not been applied because it lacks valid authentication credentials for the target resource.

--- a/contents/codes/402.md
+++ b/contents/codes/402.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":payment_required"
     "Go HTTP Status Constant": "http.StatusPaymentRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_PAYMENT_REQUIRED"
+    "Python HTTP Status Constant": "httplib.PAYMENT_REQUIRED"
 ---
 
 Reserved for future use.

--- a/contents/codes/402.md
+++ b/contents/codes/402.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":payment_required"
     "Go HTTP Status Constant": "http.StatusPaymentRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_PAYMENT_REQUIRED"
-    "Python HTTP Status Constant": "httplib.PAYMENT_REQUIRED"
+    "Python2 HTTP Status Constant": "httplib.PAYMENT_REQUIRED"
+    "Python3+ HTTP Status Constant": "http.client.PAYMENT_REQUIRED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.PAYMENT_REQUIRED"
 ---
 
 Reserved for future use.

--- a/contents/codes/403.md
+++ b/contents/codes/403.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":forbidden"
     "Go HTTP Status Constant": "http.StatusForbidden"
     "Symfony HTTP Status Constant": "Response::HTTP_FORBIDDEN"
-    "Python HTTP Status Constant": "httplib.FORBIDDEN"
+    "Python2 HTTP Status Constant": "httplib.FORBIDDEN"
+    "Python3+ HTTP Status Constant": "http.client.FORBIDDEN"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.FORBIDDEN"
 ---
 
 The server understood the request but refuses to authorize it.

--- a/contents/codes/403.md
+++ b/contents/codes/403.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":forbidden"
     "Go HTTP Status Constant": "http.StatusForbidden"
     "Symfony HTTP Status Constant": "Response::HTTP_FORBIDDEN"
+    "Python HTTP Status Constant": "httplib.FORBIDDEN"
 ---
 
 The server understood the request but refuses to authorize it.

--- a/contents/codes/404.md
+++ b/contents/codes/404.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":not_found"
     "Go HTTP Status Constant": "http.StatusNotFound"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_FOUND"
+    "Python HTTP Status Constant": "httplib.NOT_FOUND"
 ---
 
 The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.

--- a/contents/codes/404.md
+++ b/contents/codes/404.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":not_found"
     "Go HTTP Status Constant": "http.StatusNotFound"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_FOUND"
-    "Python HTTP Status Constant": "httplib.NOT_FOUND"
+    "Python2 HTTP Status Constant": "httplib.NOT_FOUND"
+    "Python3+ HTTP Status Constant": "http.client.NOT_FOUND"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NOT_FOUND"
 ---
 
 The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.

--- a/contents/codes/405.md
+++ b/contents/codes/405.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":method_not_allowed"
     "Go HTTP Status Constant": "http.StatusMethodNotAllowed"
     "Symfony HTTP Status Constant": "Response::HTTP_METHOD_NOT_ALLOWED"
+    "Python HTTP Status Constant": "httplib.METHOD_NOT_ALLOWED"
 ---
 
 The method received in the request-line is known by the origin server but not supported by the target resource.

--- a/contents/codes/405.md
+++ b/contents/codes/405.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":method_not_allowed"
     "Go HTTP Status Constant": "http.StatusMethodNotAllowed"
     "Symfony HTTP Status Constant": "Response::HTTP_METHOD_NOT_ALLOWED"
-    "Python HTTP Status Constant": "httplib.METHOD_NOT_ALLOWED"
+    "Python2 HTTP Status Constant": "httplib.METHOD_NOT_ALLOWED"
+    "Python3+ HTTP Status Constant": "http.client.METHOD_NOT_ALLOWED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.METHOD_NOT_ALLOWED"
 ---
 
 The method received in the request-line is known by the origin server but not supported by the target resource.

--- a/contents/codes/406.md
+++ b/contents/codes/406.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":not_acceptable"
     "Go HTTP Status Constant": "http.StatusNotAcceptable"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_ACCEPTABLE"
+    "Python HTTP Status Constant": "httplib.NOT_ACCEPTABLE"
 ---
 
 The target resource does not have a current representation that would be acceptable to the user agent, according to the proactive negotiation header fields received in the request<sup>[1](#ref-1)</sup>, and the server is unwilling to supply a default representation.

--- a/contents/codes/406.md
+++ b/contents/codes/406.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":not_acceptable"
     "Go HTTP Status Constant": "http.StatusNotAcceptable"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_ACCEPTABLE"
-    "Python HTTP Status Constant": "httplib.NOT_ACCEPTABLE"
+    "Python2 HTTP Status Constant": "httplib.NOT_ACCEPTABLE"
+    "Python3+ HTTP Status Constant": "http.client.NOT_ACCEPTABLE"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NOT_ACCEPTABLE"
 ---
 
 The target resource does not have a current representation that would be acceptable to the user agent, according to the proactive negotiation header fields received in the request<sup>[1](#ref-1)</sup>, and the server is unwilling to supply a default representation.

--- a/contents/codes/407.md
+++ b/contents/codes/407.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":proxy_authentication_required"
     "Go HTTP Status Constant": "http.StatusProxyAuthRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_PROXY_AUTHENTICATION_REQUIRED"
-    "Python HTTP Status Constant": "httplib.PROXY_AUTHENTICATION_REQUIRED"
+    "Python2 HTTP Status Constant": "httplib.PROXY_AUTHENTICATION_REQUIRED"
+    "Python3+ HTTP Status Constant": "http.client.PROXY_AUTHENTICATION_REQUIRED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.PROXY_AUTHENTICATION_REQUIRED"
 ---
 
 Similar to [401 Unauthorized](/401), but it indicates that the client needs to authenticate itself in order to use a proxy.

--- a/contents/codes/407.md
+++ b/contents/codes/407.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":proxy_authentication_required"
     "Go HTTP Status Constant": "http.StatusProxyAuthRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_PROXY_AUTHENTICATION_REQUIRED"
+    "Python HTTP Status Constant": "httplib.PROXY_AUTHENTICATION_REQUIRED"
 ---
 
 Similar to [401 Unauthorized](/401), but it indicates that the client needs to authenticate itself in order to use a proxy.

--- a/contents/codes/408.md
+++ b/contents/codes/408.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":request_timeout"
     "Go HTTP Status Constant": "http.StatusRequestTimeout"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_TIMEOUT"
-    "Python HTTP Status Constant": "httplib.REQUEST_TIMEOUT"
+    "Python2 HTTP Status Constant": "httplib.REQUEST_TIMEOUT"
+    "Python3+ HTTP Status Constant": "http.client.REQUEST_TIMEOUT"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.REQUEST_TIMEOUT"
 ---
 
 The server did not receive a complete request message within the time that it was prepared to wait.

--- a/contents/codes/408.md
+++ b/contents/codes/408.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":request_timeout"
     "Go HTTP Status Constant": "http.StatusRequestTimeout"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_TIMEOUT"
+    "Python HTTP Status Constant": "httplib.REQUEST_TIMEOUT"
 ---
 
 The server did not receive a complete request message within the time that it was prepared to wait.

--- a/contents/codes/409.md
+++ b/contents/codes/409.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":conflict"
     "Go HTTP Status Constant": "http.StatusConflict"
     "Symfony HTTP Status Constant": "Response::HTTP_CONFLICT"
+    "Python HTTP Status Constant": "httplib.CONFLICT"
 ---
 
 The request could not be completed due to a conflict with the current state of the target resource. This code is used in situations where the user might be able to resolve the conflict and resubmit the request.

--- a/contents/codes/409.md
+++ b/contents/codes/409.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":conflict"
     "Go HTTP Status Constant": "http.StatusConflict"
     "Symfony HTTP Status Constant": "Response::HTTP_CONFLICT"
-    "Python HTTP Status Constant": "httplib.CONFLICT"
+    "Python2 HTTP Status Constant": "httplib.CONFLICT"
+    "Python3+ HTTP Status Constant": "http.client.CONFLICT"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.CONFLICT"
 ---
 
 The request could not be completed due to a conflict with the current state of the target resource. This code is used in situations where the user might be able to resolve the conflict and resubmit the request.

--- a/contents/codes/410.md
+++ b/contents/codes/410.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":gone"
     "Go HTTP Status Constant": "http.StatusGone"
     "Symfony HTTP Status Constant": "Response::HTTP_GONE"
+    "Python HTTP Status Constant": "httplib.GONE"
 ---
 
 The target resource is no longer available at the origin server and that this condition is likely to be permanent.

--- a/contents/codes/410.md
+++ b/contents/codes/410.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":gone"
     "Go HTTP Status Constant": "http.StatusGone"
     "Symfony HTTP Status Constant": "Response::HTTP_GONE"
-    "Python HTTP Status Constant": "httplib.GONE"
+    "Python2 HTTP Status Constant": "httplib.GONE"
+    "Python3+ HTTP Status Constant": "http.client.GONE"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.GONE"
 ---
 
 The target resource is no longer available at the origin server and that this condition is likely to be permanent.

--- a/contents/codes/411.md
+++ b/contents/codes/411.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":length_required"
     "Go HTTP Status Constant": "http.StatusLengthRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_LENGTH_REQUIRED"
-    "Python HTTP Status Constant": "httplib.LENGTH_REQUIRED"
+    "Python2 HTTP Status Constant": "httplib.LENGTH_REQUIRED"
+    "Python3+ HTTP Status Constant": "http.client.LENGTH_REQUIRED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.LENGTH_REQUIRED"
 ---
 
 The server refuses to accept the request without a defined Content-Length<sup>[1](#ref-1)</sup>.

--- a/contents/codes/411.md
+++ b/contents/codes/411.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":length_required"
     "Go HTTP Status Constant": "http.StatusLengthRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_LENGTH_REQUIRED"
+    "Python HTTP Status Constant": "httplib.LENGTH_REQUIRED"
 ---
 
 The server refuses to accept the request without a defined Content-Length<sup>[1](#ref-1)</sup>.

--- a/contents/codes/412.md
+++ b/contents/codes/412.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":precondition_failed"
     "Go HTTP Status Constant": "http.StatusPreconditionFailed"
     "Symfony HTTP Status Constant": "Response::HTTP_PRECONDITION_FAILED"
-    "Python HTTP Status Constant": "httplib.PRECONDITION_FAILED"
+    "Python2 HTTP Status Constant": "httplib.PRECONDITION_FAILED"
+    "Python3+ HTTP Status Constant": "http.client.PRECONDITION_FAILED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.PRECONDITION_FAILED"
 ---
 
 One or more conditions given in the request header fields evaluated to false when tested on the server.

--- a/contents/codes/412.md
+++ b/contents/codes/412.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":precondition_failed"
     "Go HTTP Status Constant": "http.StatusPreconditionFailed"
     "Symfony HTTP Status Constant": "Response::HTTP_PRECONDITION_FAILED"
+    "Python HTTP Status Constant": "httplib.PRECONDITION_FAILED"
 ---
 
 One or more conditions given in the request header fields evaluated to false when tested on the server.

--- a/contents/codes/413.md
+++ b/contents/codes/413.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":request_entity_too_large"
     "Go HTTP Status Constant": "http.StatusRequestEntityTooLarge"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_ENTITY_TOO_LARGE"
-    "Python HTTP Status Constant": "httplib.REQUEST_ENTITY_TOO_LARGE"
+    "Python2 HTTP Status Constant": "httplib.REQUEST_ENTITY_TOO_LARGE"
+    "Python3+ HTTP Status Constant": "http.client.REQUEST_ENTITY_TOO_LARGE"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.REQUEST_ENTITY_TOO_LARGE"
 ---
 
 The server is refusing to process a request because the request payload is larger than the server is willing or able to process.

--- a/contents/codes/413.md
+++ b/contents/codes/413.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":request_entity_too_large"
     "Go HTTP Status Constant": "http.StatusRequestEntityTooLarge"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_ENTITY_TOO_LARGE"
+    "Python HTTP Status Constant": "httplib.REQUEST_ENTITY_TOO_LARGE"
 ---
 
 The server is refusing to process a request because the request payload is larger than the server is willing or able to process.

--- a/contents/codes/414.md
+++ b/contents/codes/414.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":request_uri_too_long"
     "Go HTTP Status Constant": "http.StatusRequestURITooLong"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_URI_TOO_LONG"
+    "Python HTTP Status Constant": "httplib.REQUEST_URI_TOO_LONG"
 ---
 
 The server is refusing to service the request because the request-target<sup>[1](#ref-1)</sup> is longer than the server is willing to interpret.

--- a/contents/codes/414.md
+++ b/contents/codes/414.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":request_uri_too_long"
     "Go HTTP Status Constant": "http.StatusRequestURITooLong"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_URI_TOO_LONG"
-    "Python HTTP Status Constant": "httplib.REQUEST_URI_TOO_LONG"
+    "Python2 HTTP Status Constant": "httplib.REQUEST_URI_TOO_LONG"
+    "Python3+ HTTP Status Constant": "http.client.REQUEST_URI_TOO_LONG"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.REQUEST_URI_TOO_LONG"
 ---
 
 The server is refusing to service the request because the request-target<sup>[1](#ref-1)</sup> is longer than the server is willing to interpret.

--- a/contents/codes/415.md
+++ b/contents/codes/415.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":unsupported_media_type"
     "Go HTTP Status Constant": "http.StatusUnsupportedMediaType"
     "Symfony HTTP Status Constant": "Response::HTTP_UNSUPPORTED_MEDIA_TYPE"
+    "Python HTTP Status Constant": "httplib.UNSUPPORTED_MEDIA_TYPE"
 ---
 
 The origin server is refusing to service the request because the payload is in a format not supported by this method on the target resource.

--- a/contents/codes/415.md
+++ b/contents/codes/415.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":unsupported_media_type"
     "Go HTTP Status Constant": "http.StatusUnsupportedMediaType"
     "Symfony HTTP Status Constant": "Response::HTTP_UNSUPPORTED_MEDIA_TYPE"
-    "Python HTTP Status Constant": "httplib.UNSUPPORTED_MEDIA_TYPE"
+    "Python2 HTTP Status Constant": "httplib.UNSUPPORTED_MEDIA_TYPE"
+    "Python3+ HTTP Status Constant": "http.client.UNSUPPORTED_MEDIA_TYPE"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.UNSUPPORTED_MEDIA_TYPE"
 ---
 
 The origin server is refusing to service the request because the payload is in a format not supported by this method on the target resource.

--- a/contents/codes/416.md
+++ b/contents/codes/416.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":requested_range_not_satisfiable"
     "Go HTTP Status Constant": "http.StatusRequestedRangeNotSatisfiable"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE"
-    "Python HTTP Status Constant": "httplib.REQUESTED_RANGE_NOT_SATISFIABLE"
+    "Python2 HTTP Status Constant": "httplib.REQUESTED_RANGE_NOT_SATISFIABLE"
+    "Python3+ HTTP Status Constant": "http.client.REQUESTED_RANGE_NOT_SATISFIABLE"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE"
 ---
 
 None of the ranges in the request's Range header field<sup>[1](#ref-1)</sup> overlap the current extent of the selected resource or that the set of ranges requested has been rejected due to invalid ranges or an excessive request of small or overlapping ranges.

--- a/contents/codes/416.md
+++ b/contents/codes/416.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":requested_range_not_satisfiable"
     "Go HTTP Status Constant": "http.StatusRequestedRangeNotSatisfiable"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE"
+    "Python HTTP Status Constant": "httplib.REQUESTED_RANGE_NOT_SATISFIABLE"
 ---
 
 None of the ranges in the request's Range header field<sup>[1](#ref-1)</sup> overlap the current extent of the selected resource or that the set of ranges requested has been rejected due to invalid ranges or an excessive request of small or overlapping ranges.

--- a/contents/codes/417.md
+++ b/contents/codes/417.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":expectation_failed"
     "Go HTTP Status Constant": "http.StatusExpectationFailed"
     "Symfony HTTP Status Constant": "Response::HTTP_EXPECTATION_FAILED"
+    "Python HTTP Status Constant": "httplib.EXPECTATION_FAILED"
 ---
 
 The expectation given in the request's Expect header field<sup>[1](#ref-1)</sup> could not be met by at least one of the inbound servers.

--- a/contents/codes/417.md
+++ b/contents/codes/417.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":expectation_failed"
     "Go HTTP Status Constant": "http.StatusExpectationFailed"
     "Symfony HTTP Status Constant": "Response::HTTP_EXPECTATION_FAILED"
-    "Python HTTP Status Constant": "httplib.EXPECTATION_FAILED"
+    "Python2 HTTP Status Constant": "httplib.EXPECTATION_FAILED"
+    "Python3+ HTTP Status Constant": "http.client.EXPECTATION_FAILED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.EXPECTATION_FAILED"
 ---
 
 The expectation given in the request's Expect header field<sup>[1](#ref-1)</sup> could not be met by at least one of the inbound servers.

--- a/contents/codes/424.md
+++ b/contents/codes/424.md
@@ -5,6 +5,7 @@ title: Failed Dependency
 references:
     "Rails HTTP Status Symbol": "failed_dependency"
     "Symfony HTTP Status Constant": "Response::HTTP_FAILED_DEPENDENCY"
+    "Python HTTP Status Constant": "httplib.FAILED_DEPENDENCY"
 ---
 
 The method could not be performed on the resource because the requested action depended on another action and that action failed.

--- a/contents/codes/500.md
+++ b/contents/codes/500.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":internal_server_error"
     "Go HTTP Status Constant": "http.StatusInternalServerError"
     "Symfony HTTP Status Constant": "Response::HTTP_INTERNAL_SERVER_ERROR"
+    "Python HTTP Status Constant": "httplib.INTERNAL_SERVER_ERROR"
 ---
 
 The server encountered an unexpected condition that prevented it from fulfilling the request.

--- a/contents/codes/500.md
+++ b/contents/codes/500.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":internal_server_error"
     "Go HTTP Status Constant": "http.StatusInternalServerError"
     "Symfony HTTP Status Constant": "Response::HTTP_INTERNAL_SERVER_ERROR"
-    "Python HTTP Status Constant": "httplib.INTERNAL_SERVER_ERROR"
+    "Python2 HTTP Status Constant": "httplib.INTERNAL_SERVER_ERROR"
+    "Python3+ HTTP Status Constant": "http.client.INTERNAL_SERVER_ERROR"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.INTERNAL_SERVER_ERROR"
 ---
 
 The server encountered an unexpected condition that prevented it from fulfilling the request.

--- a/contents/codes/501.md
+++ b/contents/codes/501.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":not_implemented"
     "Go HTTP Status Constant": "http.StatusNotImplemented"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_IMPLEMENTED"
+    "Python HTTP Status Constant": "httplib.NOT_IMPLEMENTED"
 ---
 
 The server does not support the functionality required to fulfill the request.

--- a/contents/codes/501.md
+++ b/contents/codes/501.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":not_implemented"
     "Go HTTP Status Constant": "http.StatusNotImplemented"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_IMPLEMENTED"
-    "Python HTTP Status Constant": "httplib.NOT_IMPLEMENTED"
+    "Python2 HTTP Status Constant": "httplib.NOT_IMPLEMENTED"
+    "Python3+ HTTP Status Constant": "http.client.NOT_IMPLEMENTED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NOT_IMPLEMENTED"
 ---
 
 The server does not support the functionality required to fulfill the request.

--- a/contents/codes/502.md
+++ b/contents/codes/502.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":bad_gateway"
     "Go HTTP Status Constant": "http.StatusBadGateway"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_GATEWAY"
-    "Python HTTP Status Constant": "httplib.BAD_GATEWAY"
+    "Python2 HTTP Status Constant": "httplib.BAD_GATEWAY"
+    "Python3+ HTTP Status Constant": "http.client.BAD_GATEWAY"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.BAD_GATEWAY"
 ---
 
 The server, while acting as a gateway or proxy, received an invalid response from an inbound server it accessed while attempting to fulfill the request.

--- a/contents/codes/502.md
+++ b/contents/codes/502.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":bad_gateway"
     "Go HTTP Status Constant": "http.StatusBadGateway"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_GATEWAY"
+    "Python HTTP Status Constant": "httplib.BAD_GATEWAY"
 ---
 
 The server, while acting as a gateway or proxy, received an invalid response from an inbound server it accessed while attempting to fulfill the request.

--- a/contents/codes/503.md
+++ b/contents/codes/503.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":service_unavailable"
     "Go HTTP Status Constant": "http.StatusServiceUnavailable"
     "Symfony HTTP Status Constant": "Response::HTTP_SERVICE_UNAVAILABLE"
-    "Python HTTP Status Constant": "httplib.SERVICE_UNAVAILABLE"
+    "Python2 HTTP Status Constant": "httplib.SERVICE_UNAVAILABLE"
+    "Python3+ HTTP Status Constant": "http.client.SERVICE_UNAVAILABLE"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.SERVICE_UNAVAILABLE"
 ---
 
 The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.

--- a/contents/codes/503.md
+++ b/contents/codes/503.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":service_unavailable"
     "Go HTTP Status Constant": "http.StatusServiceUnavailable"
     "Symfony HTTP Status Constant": "Response::HTTP_SERVICE_UNAVAILABLE"
+    "Python HTTP Status Constant": "httplib.SERVICE_UNAVAILABLE"
 ---
 
 The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.

--- a/contents/codes/504.md
+++ b/contents/codes/504.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":gateway_timeout"
     "Go HTTP Status Constant": "http.StatusGatewayTimeout"
     "Symfony HTTP Status Constant": "Response::HTTP_GATEWAY_TIMEOUT"
+    "Python HTTP Status Constant": "httplib.GATEWAY_TIMEOUT"
 ---
 
 The server, while acting as a gateway or proxy, did not receive a timely response from an upstream server it needed to access in order to complete the request.

--- a/contents/codes/504.md
+++ b/contents/codes/504.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":gateway_timeout"
     "Go HTTP Status Constant": "http.StatusGatewayTimeout"
     "Symfony HTTP Status Constant": "Response::HTTP_GATEWAY_TIMEOUT"
-    "Python HTTP Status Constant": "httplib.GATEWAY_TIMEOUT"
+    "Python2 HTTP Status Constant": "httplib.GATEWAY_TIMEOUT"
+    "Python3+ HTTP Status Constant": "http.client.GATEWAY_TIMEOUT"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.GATEWAY_TIMEOUT"
 ---
 
 The server, while acting as a gateway or proxy, did not receive a timely response from an upstream server it needed to access in order to complete the request.

--- a/contents/codes/505.md
+++ b/contents/codes/505.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": ":http_version_not_supported"
     "Go HTTP Status Constant": "http.StatusHTTPVersionNotSupported"
     "Symfony HTTP Status Constant": "Response::HTTP_VERSION_NOT_SUPPORTED"
+    "Python HTTP Status Constant": "httplib.VERSION_NOT_SUPPORTED"
 ---
 
 The server does not support, or refuses to support, the major version of HTTP that was used in the request message.

--- a/contents/codes/505.md
+++ b/contents/codes/505.md
@@ -6,7 +6,9 @@ references:
     "Rails HTTP Status Symbol": ":http_version_not_supported"
     "Go HTTP Status Constant": "http.StatusHTTPVersionNotSupported"
     "Symfony HTTP Status Constant": "Response::HTTP_VERSION_NOT_SUPPORTED"
-    "Python HTTP Status Constant": "httplib.VERSION_NOT_SUPPORTED"
+    "Python2 HTTP Status Constant": "httplib.VERSION_NOT_SUPPORTED"
+    "Python3+ HTTP Status Constant": "http.client.VERSION_NOT_SUPPORTED"
+    "Python3.5+ HTTP Status Constant": "http.HTTPStatus.VERSION_NOT_SUPPORTED"
 ---
 
 The server does not support, or refuses to support, the major version of HTTP that was used in the request message.


### PR DESCRIPTION
Add Python status constants, a total of 41, include [200, 201, 202, 203, 204, 205, 206, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 100, 101, 300, 301, 302, 303, 304, 305, 306, 307, 500, 501, 502, 503, 504, 505]